### PR TITLE
Fix #45 Robust handling of inconsistent TabularInput keys

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -50,18 +50,19 @@ class CsvOutput(FileOutput):
                 # read existing file and write back with new fieldname
                 # self._log_file contains: name, mode, encoding
                 # <_io.TextIOWrapper name='out.csv' mode='w' encoding='cp1252'>
-                with open(self._log_file.name, "r", newline="") as csvfileog:
-                    og_data = csv.DictReader(csvfileog)
+                with open(self._log_file.name, "r") as csvfileog:
+                    original_data = csv.DictReader(csvfileog)
 
                     self._writer = csv.DictWriter(
                     self._log_file,
                     fieldnames=self._fieldnames,
-                    extrasaction='ignore')
+                    extrasaction='raise')
+                    self._log_file.seek(0)
+                    self._writer = self.csvwriter(self._log_file, self._fieldnames, 'ignore', True)
 
                     # overwrite the file from beginning
-                    self._log_file.seek(0)
-                    self._writer.writeheader()
-                    for row in og_data:
+                    
+                    for row in original_data:
                         self._writer.writerow(row)
 
             self._writer.writerow(to_csv)
@@ -70,6 +71,15 @@ class CsvOutput(FileOutput):
                 data.mark(k)
         else:
             raise ValueError('Unacceptable type.')
+
+    def csvwriter (self, filename, fieldnames,extrasaction,writeheader):
+        writer = csv.DictWriter(
+            filename,
+            fieldnames = fieldnames,
+            extrasaction = extrasaction)
+        if writeheader:
+            self._writer.writeheader()
+        return writer
 
     def _warn(self, msg):
         """Warns the user using warnings.warn.

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -42,12 +42,27 @@ class CsvOutput(FileOutput):
                 self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
-                self._warn('Inconsistent TabularInput keys detected. '
-                           'CsvOutput keys: {}. '
-                           'TabularInput keys: {}. '
-                           'Did you change key sets after your first '
-                           'logger.log(TabularInput)?'.format(
-                               set(self._fieldnames), set(to_csv.keys())))
+                                
+                # update new field name
+                new_field = set(to_csv.keys())
+                self._fieldnames.update(new_field)
+
+                # read existing file and write back with new fieldname
+                # self._log_file contains: name, mode, encoding
+                # <_io.TextIOWrapper name='out.csv' mode='w' encoding='cp1252'>
+                with open(self._log_file.name, "r", newline="") as csvfileog:
+                    og_data = csv.DictReader(csvfileog)
+
+                    self._writer = csv.DictWriter(
+                    self._log_file,
+                    fieldnames=self._fieldnames,
+                    extrasaction='ignore')
+
+                    # overwrite the file from beginning
+                    self._log_file.seek(0)
+                    self._writer.writeheader()
+                    for row in og_data:
+                        self._writer.writerow(row)
 
             self._writer.writerow(to_csv)
 

--- a/src/doweltest.py
+++ b/src/doweltest.py
@@ -17,8 +17,8 @@ for i in range(4):
         tabular.record('new_data', i)
     if i > 1:
         tabular.record('brand_new_data', i+i)
-    if i > 2:
         tabular.record('brand_brand_new_data', i+1)
+
 
     logger.log(tabular)
 

--- a/src/doweltest.py
+++ b/src/doweltest.py
@@ -1,0 +1,28 @@
+import dowel
+from dowel import logger, tabular
+
+logger.add_output(dowel.StdOutput())
+logger.add_output(dowel.CsvOutput('out.csv'))
+
+logger.log('Starting up...')
+for i in range(4):
+    logger.push_prefix('itr {} '.format(i))
+    logger.log('Running training step')
+
+    tabular.record('itr', i)
+    tabular.record('loss', 100.0 / (2 + i))
+
+    # the addition of new data to tabular breaks logging to CSV
+    if i > 0:
+        tabular.record('new_data', i)
+    if i > 1:
+        tabular.record('brand_new_data', i+i)
+    if i > 2:
+        tabular.record('brand_brand_new_data', i+1)
+
+    logger.log(tabular)
+
+    logger.pop_prefix()
+    logger.dump_all()
+
+logger.remove_all() 


### PR DESCRIPTION
The issue was caused by inconsistent fieldnames. To fix this issue, I first update the fieldnames to original + new fieldnames, and then read all previous data from csv file, finally write back with updated fieldname with blank data in new fieldnames. rlworkgroup#45